### PR TITLE
Readに関する例外ハンドリング実装

### DIFF
--- a/src/main/java/com/example/raiseTechcoursetask10/controller/SkiresortController.java
+++ b/src/main/java/com/example/raiseTechcoursetask10/controller/SkiresortController.java
@@ -3,13 +3,18 @@ package com.example.raisetechcoursetask10.controller;
 import com.example.raisetechcoursetask10.controller.form.SkiresortCreateForm;
 import com.example.raisetechcoursetask10.controller.response.SkiresortResponse;
 import com.example.raisetechcoursetask10.entity.Skiresort;
+import com.example.raisetechcoursetask10.exception.ResourceNotFoundException;
 import com.example.raisetechcoursetask10.service.SkiresortService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 public class SkiresortController {
@@ -31,6 +36,22 @@ public class SkiresortController {
         Skiresort skiresort = skiresortService.findById(id);
         return new SkiresortResponse(skiresort);
     }
+
+    @ExceptionHandler(value = ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> noResourceFound(
+            ResourceNotFoundException e, HttpServletRequest request) {
+
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+
+        // 404エラーを返す
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+
 
     @PostMapping("/skiresorts")
     public ResponseEntity<SkiresortResponse> createSkiresort(@RequestBody SkiresortCreateForm skiresortCreateForm) {

--- a/src/main/java/com/example/raiseTechcoursetask10/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/raiseTechcoursetask10/exception/ResourceNotFoundException.java
@@ -1,0 +1,22 @@
+package com.example.raisetechcoursetask10.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException() {
+        super();
+    }
+
+    // 指定されたメッセージと原因を持つ例外を作成する
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    // 指定されたメッセージを持つ例外を作成する
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    // 指定された原因を持つ例外を作成する
+    public ResourceNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/example/raiseTechcoursetask10/mapper/SkiresortMapper.java
+++ b/src/main/java/com/example/raiseTechcoursetask10/mapper/SkiresortMapper.java
@@ -15,7 +15,6 @@ public interface SkiresortMapper {
     List<Skiresort> findAll();
 
     @Select("SELECT * FROM skiresort WHERE id = #{id}")
-//    Skiresort findById(int id);
     Optional<Skiresort> findById(int id);
 
     @Insert("INSERT INTO skiresort (id, name, area, customerEvaluation) VALUES (#{id}, #{name}, #{area}, #{customerEvaluation})")

--- a/src/main/java/com/example/raiseTechcoursetask10/mapper/SkiresortMapper.java
+++ b/src/main/java/com/example/raiseTechcoursetask10/mapper/SkiresortMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface SkiresortMapper {
@@ -14,7 +15,8 @@ public interface SkiresortMapper {
     List<Skiresort> findAll();
 
     @Select("SELECT * FROM skiresort WHERE id = #{id}")
-    Skiresort findById(int id);
+//    Skiresort findById(int id);
+    Optional<Skiresort> findById(int id);
 
     @Insert("INSERT INTO skiresort (id, name, area, customerEvaluation) VALUES (#{id}, #{name}, #{area}, #{customerEvaluation})")
     @Options(useGeneratedKeys = true, keyProperty = "id")

--- a/src/main/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImpl.java
+++ b/src/main/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImpl.java
@@ -2,10 +2,12 @@ package com.example.raisetechcoursetask10.service;
 
 import com.example.raisetechcoursetask10.controller.form.SkiresortCreateForm;
 import com.example.raisetechcoursetask10.entity.Skiresort;
+import com.example.raisetechcoursetask10.exception.ResourceNotFoundException;
 import com.example.raisetechcoursetask10.mapper.SkiresortMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class SkiresortServiceImpl implements SkiresortService {
@@ -25,7 +27,8 @@ public class SkiresortServiceImpl implements SkiresortService {
 
     @Override
     public Skiresort findById(int id) {
-        return skiresortMapper.findById(id);
+        Optional<Skiresort> skiresort = this.skiresortMapper.findById(id);
+        return skiresort.orElseThrow(() -> new ResourceNotFoundException("resource not found"));
     }
 
     @Override


### PR DESCRIPTION
# 存在しないidを指定した場合404エラーを返す

## 実装内容

ブランチ：#1_feature/crudapi
| 実装済み | 内容 |
| ---- | ---- |
| Read | skiresortテーブルの全データを取得する |
| Read(id)| 指定した既存idのデータを取得する |
| Create | 新規id5を作成 |

ブランチ：#3_feature/errorHandling
| 今回の実装 | 内容 |
| ---- | ---- |
| ErrorHandling | 存在しないidを指定して取得する例外処理 |

| 実装予定 | 内容 |
| ---- | ---- |
| Update | id5のname,customerEvaluationデータ更新する |
| Delete | idを指定して1レコードを削除する |
| ErrorHandling | nameに対する制御 |

## 実装順理由
| 順番 | 機能 | 理由 |
| :---: | ---- | ---- |
| 1 | Read | テーブルの全てのデータを取得してから開始するため |
| 2 | Read(id) | idに関するErrorHandlingを実装するため |
| 3 | idのErrorHandling | アプリケーションの安定性と信頼性を向上させるために重要な要素であり、早い段階で実装するべきと考えたため |
| | |
| 4 | Update | Createした仮データを完成させるため |
| 5 | nameのErrorHandling | 早い段階で実装すべきだが、Update作成後にテストするため |
| 6 | Delete | 実装予定機能が完了してからDeleteするため |

## curlコマンド
`curl http://localhost:8080/skiresorts/99 -i`

`curl http://localhost:8080/skiresorts/55 -i`

## 動作確認ポイント

| 項目 | レスポンス |
| ---- | ---- |
| HTTP | 1.1 404 |
| Content-Type | application/json |
| error | Not Found" |
| message | "resource not found" |
| status | "404" |
| path | "99"/"55" |

## 動作確認キャプチャ

![2C477B19-77AE-481D-96CC-716618B99999_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/172039f9-cf55-4381-8d2e-68cee9890da7)
