### PR TITLE
Service単体テスト：存在するスキー場のIDを指定したときに正常にデータが返されること

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -1,11 +1,12 @@
-<details><summary>DBテスト</summary><div>
+# 単体テスト
 
-<details><summary>@DBRiderの場合</summary><div>
+# DBテスト
 
+## @DBRiderの場合
 
-@DataSet：更新前のテーブル[引数にvalue:パスを書く]
+- @DataSet：更新前のテーブル[引数にvalue:パスを書く]
 
-@ExpectedDataSet：期待値データ[引数にvalue:パスを書く]
+- @ExpectedDataSet：期待値データ[引数にvalue:パスを書く]
 
 updateSkiresortはSkiresortクラスを引数に取るわけですから、呼び出し方を変えないといけないですね。
 
@@ -37,7 +38,7 @@ id=1, area="山形"
 id=2, area="新潟"
 ```
 
-<details><summary>考え方</summary><div>
+## 考え方
 
 - テストコードに書くメソッドはMapper.javaに書いてあること必須！！
 - 全てのスキーリゾートが取得できること
@@ -69,7 +70,7 @@ id=2, area="新潟"
     - 比較する必要があるため、初期値と期待値のymlファイルが必要（同じデータが良い）
     - Mapperのメソッド名の引数に存在しないidを書く
 
-<details><summary>テスト結果表示方法</summary><div>
+## テスト結果表示方法
 
 - テスト結果を確認したい
 
@@ -85,3 +86,44 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 ```
 
 - htmlファイルが作成されているので、ディレクトリで`index.html`を探す
+
+# Serviceテスト
+
+- モック：偽物。本物のフリをする
+- スタブ：代理。代わりのものを使う
+
+## 考え方
+
+- ServiceがMapperに依存している状態なので、そのまま書くとエラー
+
+  -> 単体テストなので、Mapperに依存できない
+- 依存しているクラスをモック化する
+
+- スタブ化（モック化）したMapperの状態を確認する
+- DBは無関係
+- doReturn：期待値を定義
+
+### 準備
+
+- `@ExtendWith(MockitoExtension.class)`
+
+-> Mockitoを使用できるようにclassに付ける
+
+- classに`@ExtendWith(MockitoExtension.class)` // JUnit5でMockitoを使うため
+- `@Mock` // モック化（スタブ化）する対象に定義
+- `@InjectMocks` // テスト対象に定義 @Mockでモックにしたインスタンスの注入先となるインスタンスに定義（インターフェースに付けるとエラー）
+
+### 実装
+
+- `doReturn`：期待値を定義
+- `Skiresort actual`:doReturn -whenで定義した期待値が入る
+
+折りたたみ
+
+```
+<details><summary>Hello</summary><blockquote>
+  <details><summary>World</summary><blockquote>
+    :smile:
+  </blockquote></details>
+</blockquote></details>
+```

--- a/memo.md
+++ b/memo.md
@@ -72,7 +72,7 @@ id=2, area="新潟"
 
 ## テスト結果表示方法
 
-- テスト結果を確認したい
+- テスト結果レポートを作成したい
 
 ```
 ./gradlew test --tests "com.example.raiseTechcoursetask10.RaiseTechCourseTask10ApplicationTests" --info
@@ -121,12 +121,20 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 
 ### 実装
 
-- `doReturn`：Mapperの動作をスタブ化しているので、テスト期待値と等しくなる
-- `Skiresort actual`:doReturn -whenで定義した値が入る
-- `assertThat(actual)`:Serviceが返した実際の値を検証している
+- `doReturn`：Mapperの動作をスタブ化している仮のデータを定義している
+- `Skiresort actual`:実際の値が入る
+- `assertThat`:テスト対象の実行結果やオブジェクトの状態を期待する値や条件と比較する
+- `assertThat(actual)`:`assertThat`の引数`(actual)`に実際の値を定義する。Serviceが返した実際の値をassertThat(検証/比較)している
+- `assertThat(actual).isEqualTo(期待値となる値)`:期待値は`.isEqualTo`の引数に定義する
 - アサーションのimport文に気を付ける
 
-折りたたみ
+
+- 存在するidを指定した時、正常にデータが返されること
+    - `doReturn -when`:スタブ化したid1のデータを定義する
+    - `assertThat(actual).isEqualTo()`：.isEqualToの引数に、期待値データを定義する
+    - `verify`：1回だけid1が呼び出されたかを確認する
+
+【折りたたみ】
 
 ```
 <details><summary>Hello</summary><blockquote>

--- a/memo.md
+++ b/memo.md
@@ -101,7 +101,13 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 
 - スタブ化（モック化）したMapperの状態を確認する
 - DBは無関係
-- doReturn：期待値を定義
+- doReturn：値を返すメソッドをスタブ化（モック化）したときに返す値を定義するためのメソッド
+
+モックオブジェクトが特定のメソッド呼び出しに対して、特定の値を返すように指定するために使用される
+
+モックオブジェクトがgetSomeValue()メソッドが呼ばれたときに42を返すように設定する例
+
+```doReturn(42).when(someMock).getSomeValue();```
 
 ### 準備
 
@@ -115,8 +121,10 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 
 ### 実装
 
-- `doReturn`：期待値を定義
-- `Skiresort actual`:doReturn -whenで定義した期待値が入る
+- `doReturn`：Mapperの動作をスタブ化しているので、テスト期待値と等しくなる
+- `Skiresort actual`:doReturn -whenで定義した値が入る
+- `assertThat(actual)`:Serviceが返した実際の値を検証している
+- アサーションのimport文に気を付ける
 
 折りたたみ
 

--- a/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
@@ -26,7 +26,7 @@ class SkiresortServiceImplTest {
     SkiresortMapper skiresortMapper;
 
     @Test
-    public void 存在するユーザのIDを指定したときに正常にデータが返されること() throws Exception {
+    public void 存在するスキー場のIDを指定したときに正常にデータが返されること() throws Exception {
         // doReturn -when :Mokietoの記述
         doReturn(Optional.of(new Skiresort(1, "たかつえ", "福島県", "いつも空いてて1枚バーンが気持ちいい"))).when(skiresortMapper).findById(1);
 

--- a/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
@@ -1,0 +1,38 @@
+package com.example.raiseTechcoursetask10.service;
+
+import com.example.raisetechcoursetask10.entity.Skiresort;
+import com.example.raisetechcoursetask10.mapper.SkiresortMapper;
+import com.example.raisetechcoursetask10.service.SkiresortServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class) // JUnit5でMockitoを使うために必要
+class SkiresortServiceImplTest {
+
+    @InjectMocks // テスト対象
+    SkiresortServiceImpl skiresortServiceImpl;
+
+    @Mock // モック化（スタブ化）したいインスタンスに定義
+    SkiresortMapper skiresortMapper;
+
+    @Test
+    public void 存在するユーザのIDを指定したときに正常にデータが返されること() throws Exception {
+        // doReturn -when :Mokietoの記述
+        doReturn(Optional.of(new Skiresort(1, "たかつえ", "福島県", "いつも空いてて1枚バーンが気持ちいい"))).when(skiresortMapper).findById(1);
+
+        // testの実行
+        Skiresort actual = skiresortServiceImpl.findById(1);
+        assertThat(actual).isEqualTo(new Skiresort(1, "たかつえ", "福島県", "いつも空いてて1枚バーンが気持ちいい"));
+        verify(skiresortMapper, times(1)).findById(1);
+    }
+}


### PR DESCRIPTION
# Serviceの単体テスト

## テスト内容
id1を指定したテストを実装

## 動作確認キャプチャ

![DBD9A290-B791-4040-B15F-735AEC372E23_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/9afd4cb1-ed6b-4240-b527-15c3d33494c5)

## テスト結果レポート

![12F60A82-A5D1-4CA8-854B-B8A80785D4EC](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/745679f3-8330-4d6d-84b5-7ad37947d2ba)

![8BEF8EB5-2845-440F-9C34-9B45D0D01EEB](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/b2722573-9038-404e-b5af-f85c0230b141)
