### PR TITLE
Service単体テスト：全てのデータを取得できることの実装

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -128,11 +128,20 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 - `assertThat(actual).isEqualTo(期待値となる値)`:期待値は`.isEqualTo`の引数に定義する
 - アサーションのimport文に気を付ける
 
+### doReturnの書き方
+
+- ` when(モックインスタンス.メソッド(引数)).thenReturn(戻り値)`;
+
+- ` doReturn(戻り値).when(モックインスタンス).メソッド(引数);`
 
 - 存在するidを指定した時、正常にデータが返されること
     - `doReturn -when`:スタブ化したid1のデータを定義する
     - `assertThat(actual).isEqualTo()`：.isEqualToの引数に、期待値データを定義する
     - `verify`：1回だけid1が呼び出されたかを確認する
+
+- 全てのデータを取得する
+    - リスト化する
+    - `actual`:テストしたい実際の値をリスト型のactualに代入する
 
 【折りたたみ】
 

--- a/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,5 +35,24 @@ class SkiresortServiceImplTest {
         Skiresort actual = skiresortServiceImpl.findById(1);
         assertThat(actual).isEqualTo(new Skiresort(1, "たかつえ", "福島県", "いつも空いてて1枚バーンが気持ちいい"));
         verify(skiresortMapper, times(1)).findById(1);
+    }
+
+    @Test
+    public void 全てのスキー場情報を取得できること() {
+
+        List<Skiresort> skiresorts = List.of(
+                new Skiresort(1, "Cadrona", "NZ", "パイプのnationals公式大会で優勝して、副賞モルディブ1週間旅行だった！ゲレンデはコンクリートみたいに硬い"),
+                new Skiresort(2, "Whistler", "canada", "滞在2週間の半分以上雨で、記録的な少雪な年だった"),
+                new Skiresort(3, "Mt.Hood", "Oregon", "標高が高すぎて高山病になった。ガスってる日に2000m以上続く急斜面で滑落した"));
+
+        // 依存しているSkiresortMapperをモック化する
+        // skiresortMapperのfindAll()メソッドが呼ばれた時に、skiresortsリストを返す
+        doReturn(skiresorts).when(skiresortMapper).findAll();
+
+        // test実行
+        List<Skiresort> actual = skiresortServiceImpl.findAll();
+        // actual(実際)の値がモック化した値(skiresorts)と等しいか検証する
+        assertThat(actual).isEqualTo(skiresorts);
+        verify(skiresortMapper, times(1)).findAll();
     }
 }


### PR DESCRIPTION
# 単体テスト全てのスキー場情報を取得できることの実装

## 動作確認キャプチャ
![2110D0F7-F12A-4DC8-801B-71B698853713_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/19fd7c68-43fc-4f72-ad00-fcb58661123c)

## テスト結果レポート
![6099F183-B9C2-4FF0-B5B8-95E87528CBCF](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/8865eb33-a55d-43d7-bec8-74433b973646)

![B0C822EA-0421-4064-9280-CA9620FBEBE4](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/1b080ac7-2187-4175-b253-eac9bfcfdf28)
