### PR TITLE
Service単体テスト：存在しないIDを指定した時エラーメッセージが表示されることの実装

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -102,6 +102,7 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 - スタブ化（モック化）したMapperの状態を確認する
 - DBは無関係
 - doReturn：値を返すメソッドをスタブ化（モック化）したときに返す値を定義するためのメソッド
+- 検査例外と非検査例外：`throws Exception`をメソッドにつけないとコンパイルエラーになるのは、検査例外を`throw`するかもしれないメソッドを呼び出すときのみ
 
 モックオブジェクトが特定のメソッド呼び出しに対して、特定の値を返すように指定するために使用される
 
@@ -121,6 +122,7 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 
 ### 実装
 
+- `throws Exception`:テスト対象が検査例外をthrowするかどうかで必要不要を判断する。Mapperの返す値によって例外を起こしそうな場合は必要
 - `doReturn`：Mapperの動作をスタブ化している仮のデータを定義している
 - `Skiresort actual`:実際の値が入る
 - `assertThat`:テスト対象の実行結果やオブジェクトの状態を期待する値や条件と比較する
@@ -142,6 +144,12 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 - 全てのデータを取得する
     - リスト化する
     - `actual`:テストしたい実際の値をリスト型のactualに代入する
+
+- 存在しないIDを指定した時エラーメッセージが返されること
+    - `throws Exception`:必要？不要？存在しないIDを指定した時にMapperは一体どんな値を返すのかを考える
+    - `assertThatThrownBy()`: 例外の検証ができる
+    - `isinstanceof()`:対象のメソッドを実行した時にthrowされる例外が、何インスタンスか？を検証している
+    - `ResourceNotFoundException`:指定したIDに該当するリソースがないことを通知する例外
 
 【折りたたみ】
 

--- a/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.example.raiseTechcoursetask10.service;
 
 import com.example.raisetechcoursetask10.entity.Skiresort;
+import com.example.raisetechcoursetask10.exception.ResourceNotFoundException;
 import com.example.raisetechcoursetask10.mapper.SkiresortMapper;
 import com.example.raisetechcoursetask10.service.SkiresortServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,7 +41,6 @@ class SkiresortServiceImplTest {
 
     @Test
     public void 全てのスキー場情報を取得できること() {
-
         List<Skiresort> skiresorts = List.of(
                 new Skiresort(1, "Cadrona", "NZ", "パイプのnationals公式大会で優勝して、副賞モルディブ1週間旅行だった！ゲレンデはコンクリートみたいに硬い"),
                 new Skiresort(2, "Whistler", "canada", "滞在2週間の半分以上雨で、記録的な少雪な年だった"),
@@ -54,5 +55,17 @@ class SkiresortServiceImplTest {
         // actual(実際)の値がモック化した値(skiresorts)と等しいか検証する
         assertThat(actual).isEqualTo(skiresorts);
         verify(skiresortMapper, times(1)).findAll();
+    }
+
+    @Test
+    public void 存在しないIDを指定した時エラーメッセージが返されること() throws Exception {
+        // モック化　id100を指定したとき空かどうか
+        doReturn(Optional.empty()).when(skiresortMapper).findById(100);
+
+        // test実行　memberServiceImpl.findByIdメソッドにid100を渡した時、例外をスローすることを期待している
+        assertThatThrownBy(() -> skiresortServiceImpl.findById(100)) // テスト対象メソッド
+                // throwされる例外がResourceNotFoundException（リソースがないことを通知する）を返す
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("resource not found");
     }
 }


### PR DESCRIPTION
# Service単体テスト：存在しないIDを指定した時に、期待通りのメッセージ（resource not found）を返すことの実装

# 動作確認キャプチャ

![CF4BCD4D-334F-466B-93AC-F9A2702EE39F_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/986c53fe-19ae-441d-aa49-991f5fe55306)

# テスト結果レポート
![B431B70E-0066-486D-B2E9-3A2EA69F225D](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/336562fd-f81f-4b30-8d70-ba492df12f94)

![251ACEEC-2A28-4E06-8159-2179759D2F96](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/3379ba3b-2a16-4d99-9418-3d5bfd746dcf)
