### PR TITLE
Service単体テスト：指定したidのスキー場情報を更新できることの実装

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -41,6 +41,12 @@ id=2, area="新潟"
 ## 考え方
 
 - テストコードに書くメソッドはMapper.javaに書いてあること必須！！
+- 検査例外と非検査例外
+    - 検査例外：プログラマが予想して対応できるエラー。Exceptionクラス配下のRuntime Exception以外のクラスが対象。
+    - 例外（exception）のうち、メソッドの呼び出し側に`try-catch`文による例外処理の記述が要請されるもの
+    - 非検査例外：プログラマが予測できないエラー
+- RuntimeException:実行時の例外を拾うことができる
+
 - 全てのスキーリゾートが取得できること
     - 比較データ（ymlファイル）は1つで良い
     - `hasSize()`内にデータのサイズを書く
@@ -88,6 +94,10 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 - htmlファイルが作成されているので、ディレクトリで`index.html`を探す
 
 # Serviceテスト
+
+### `Skiresort:`スキーリゾートの情報を保持するためのクラス
+
+### `SkiresortServiceImpl:`スキーリゾート情報を操作するためのサービスクラス
 
 - モック：偽物。本物のフリをする
 - スタブ：代理。代わりのものを使う
@@ -150,6 +160,18 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
     - `assertThatThrownBy()`: 例外の検証ができる
     - `isinstanceof()`:対象のメソッドを実行した時にthrowされる例外が、何インスタンスか？を検証している
     - `ResourceNotFoundException`:指定したIDに該当するリソースがないことを通知する例外
+
+- 指定したIDの情報を更新できること
+
+1. `skiresortMapper`の`findById`メソッドを使って更新前のデータを取得する ->`doReturn -when`:whenに更新前データを定義する
+2. `skiresortServiceImpl`オブジェクトの`updateSkiresort`メソッドを呼び出す。このメソッドは、指定したIDのスキーリゾート情報を更新する->`Lake Louise`
+3. `verify`:skiresortMapperオブジェクトのID1が1回呼ばれたことの検証。
+4. 新しい`Skiresort`インスタンスを作成し、変数`updateSkiresort`に更新後データ`Lake Louise`を設定する。->
+   Skiresortのインスタンス化updateSkiresortを定義しないとエラー
+5.
+    - `verify`:skiresortMapperオブジェクトのupdateSkiresortメソッドが1回呼ばれたことの検証
+    - verifyの検証時に`updateSkiresort`を渡す-> `MockitoはskiresortMapper.updateSkiresort`に更新後の`Lake Louise`
+      の情報が渡されたのだよねという検証までしてくれる
 
 【折りたたみ】
 

--- a/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/raiseTechcoursetask10/service/SkiresortServiceImplTest.java
@@ -29,7 +29,7 @@ class SkiresortServiceImplTest {
     SkiresortMapper skiresortMapper;
 
     @Test
-    public void 存在するスキー場のIDを指定したときに正常にデータが返されること() throws Exception {
+    public void 存在するスキー場のIDを指定したときに正常にデータが返されること() {
         // doReturn -when :Mokietoの記述
         doReturn(Optional.of(new Skiresort(1, "たかつえ", "福島県", "いつも空いてて1枚バーンが気持ちいい"))).when(skiresortMapper).findById(1);
 
@@ -43,7 +43,7 @@ class SkiresortServiceImplTest {
     public void 全てのスキー場情報を取得できること() {
         List<Skiresort> skiresorts = List.of(
                 new Skiresort(1, "Cadrona", "NZ", "パイプのnationals公式大会で優勝して、副賞モルディブ1週間旅行だった！ゲレンデはコンクリートみたいに硬い"),
-                new Skiresort(2, "Whistler", "canada", "滞在2週間の半分以上雨で、記録的な少雪な年だった"),
+                new Skiresort(2, "Whistler", "Canada", "滞在2週間の半分以上雨で、記録的な少雪な年だった"),
                 new Skiresort(3, "Mt.Hood", "Oregon", "標高が高すぎて高山病になった。ガスってる日に2000m以上続く急斜面で滑落した"));
 
         // 依存しているSkiresortMapperをモック化する
@@ -58,7 +58,7 @@ class SkiresortServiceImplTest {
     }
 
     @Test
-    public void 存在しないIDを指定した時エラーメッセージが返されること() throws Exception {
+    public void 存在しないIDを指定した時エラーメッセージが返されること() {
         // モック化　id100を指定したとき空かどうか
         doReturn(Optional.empty()).when(skiresortMapper).findById(100);
 
@@ -67,5 +67,24 @@ class SkiresortServiceImplTest {
                 // throwされる例外がResourceNotFoundException（リソースがないことを通知する）を返す
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("resource not found");
+        verify(skiresortMapper, times(1)).findById(100);
+    }
+
+    @Test
+    public void 指定したidのスキー場情報を更新できること() {
+        // モック化　returnするSkiresortは更新前のデータを設定
+        doReturn(Optional.of(new Skiresort(1, "Whistler", "Canada", "11kmのロングランが楽しめる。次回は天気の良いハイシーズンに行きたい"))).when(skiresortMapper).findById(1);
+        // updateSkiresortメソッドを呼び出して、id1が持つ情報をLake Louiseに更新する
+        skiresortServiceImpl.updateSkiresort(1, "Lake Louise", "Canada", "バンフから近くて無料シャトルバスがある。広大で美しいゲレンデ");
+
+        // skiresortMapperオブジェクトのID1が1回呼ばれたことの検証
+        verify(skiresortMapper, times(1)).findById(1);
+
+        // Skiresortのインスタンス定義
+        // これが更新後のデータの期待値 Lake Louise->Skiresortのインスタンス化updateSkiresortを定義しないとエラー
+        Skiresort updateSkiresort = new Skiresort(1, "Lake Louise", "Canada", "バンフから近くて無料シャトルバスがある。広大で美しいゲレンデ");
+        // skiresortMapperオブジェクトのupdateSkiresortByIdメソッドが1回呼ばれたことの検証
+        // skiresortMapperのupdateSkiresortメソッドの引数updateSkiresort変数が渡されて、更新後データであるLake Louiseであることを検証する
+        verify(skiresortMapper, times(1)).updateSkiresort(updateSkiresort);
     }
 }


### PR DESCRIPTION
# Service単体テスト：id1のスキーリゾード情報が正常に更新できるかを検証する

## 苦労したこと
- Mapperテストのように、明示的に初期値、期待値というファイル及び実装概念がないため、モック化するデータが更新前のデータ化か更新後のデータかということもしっかり理解できなかった。
- どこで更新データを定義するのか、何回定義すれば「変数が定義されていません」のエラーが解消されるのかというJavaの文法も再確認する必要があった。
- `assertThat`や`actual`を使用しないパターンが初めてで、verifyで検証する内容が異なる場合の書き方がわからなかった。

## 動作確認キャプチャ
![E1736473-59B4-4963-B358-5298C407FBFD_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/1c577687-6704-4215-8a67-3f7107fda4c4)

## テスト結果レポート
![A86338C7-4389-4879-9B93-3D9A8335E1AE](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/2ccd51b3-166b-4bc9-95d4-b515282db7c6)

![6719D0EF-5FCC-4956-A043-6139EB9F2737](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/a488f315-a1c7-4627-ad22-ed5b4d5d1a3a)
