### PR TITLE
Service単体テスト：指定したIDのスキー場情報を削除できることの実装

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -144,7 +144,7 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 
 ### エラー
 
-- `staticでないメソッド deleteSkiresort(int)をstaticコンテキストから参照することはできません`:staticメソッドの呼び出し方だとエラー
+- `staticでないメソッド deleteSkiresort(int)をstaticコンテキストから参照することはできません`:インスタンスメソッドをstaticメソッドの呼び出し方で呼び出していたのでエラー
   -> staticメソッド = クラスメソッド
   
 
@@ -164,9 +164,9 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
     - `actual`:テストしたい実際の値をリスト型のactualに代入する
 
 - skiresortMapperに存在しないIDを指定した時エラーメッセージが返されること
-  - `throws Exception`:必要？不要？存在しないIDを指定した時にMapperは一体どんな値を返すのかを考える
+  - `throws Exception`:テストケース内で呼び出すメソッドが検査例外をthrowしうる場合必要
   - `assertThatThrownBy()`: 例外の検証ができる
-  - `isinstanceof()`:対象のメソッドを実行した時にthrowされる例外が、何インスタンスか？を検証している
+  - `isInstanceof()`:対象のメソッドを実行した時にthrowされる例外が、何インスタンスか？を検証している
   - `ResourceNotFoundException`:指定したIDに該当するリソースがないことを通知する例外
 
 - 指定したIDの情報を更新できること
@@ -175,7 +175,7 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 2. `skiresortServiceImpl`オブジェクトの`updateSkiresort`メソッドを呼び出す。このメソッドは、指定したIDのスキーリゾート情報を更新する->`Lake Louise`
 3. `verify`:skiresortMapperオブジェクトのID1が1回呼ばれたことの検証。
 4. 新しい`Skiresort`インスタンスを作成し、変数`updateSkiresort`に更新後データ`Lake Louise`を設定する。-> Skiresortのインスタンス化updateSkiresortを定義しないとエラーになる
-5. `updateSkiresort`: 戻り値がvoidなのでassertThatできない -> 代替としてverifyでfindByIdを使って検証する
+5. `updateSkiresort`: 戻り値がvoidなのでassertThatできない -> 代替としてverifyを使って検証する
    - `verify`:skiresortMapperオブジェクトのupdateSkiresortメソッドが1回呼ばれたことの検証
    - verifyの検証時に`updateSkiresort`を渡す-> `MockitoはskiresortMapper.updateSkiresort`に更新後の`Lake Louise`
      の情報が渡されたのだよねという検証までしてくれる
@@ -186,13 +186,8 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
   
 - 指定したIDのスキー場情報を削除する
   - `doReturn`:対象のIDのスキー場情報をモック化して`when`でskiresortMapperで対象IDを検索する
-  - `void`：deleteSkiresortはvoidのため、assertThatは使えない -> findByIdで呼び出す
-  - staticでないメソッド deleteSkiresort(int)をstaticコンテキストから参照することはできませんエラーが表示->staticメソッドの呼び出し方だとエラー->staticメソッド = クラスメソッド
-
-
-
-
-
+  - `void`：deleteSkiresortはvoidのため、assertThatは使えない
+  - staticでないメソッド deleteSkiresort(int)をstaticコンテキストから参照することはできませんエラーが表示->インスタンスメソッドをstaticメソッドの呼び出し方で呼び出していたのでエラー->staticメソッド = クラスメソッド
 
 
 【折りたたみ】

--- a/memo.md
+++ b/memo.md
@@ -132,7 +132,7 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 - `@Mock` // モック化（スタブ化）する対象に定義
 - `@InjectMocks` // テスト対象に定義 @Mockでモックにしたインスタンスの注入先となるインスタンスに定義（インターフェースに付けるとエラー）
 
-### 実装
+### 実装概要
 
 - `throws Exception`:テスト対象が検査例外をthrowするかどうかで必要不要を判断する。Mapperの返す値によって例外を起こしそうな場合は必要
 - `doReturn`：Mapperの動作をスタブ化している仮のデータを定義している
@@ -141,6 +141,12 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
 - `assertThat(actual)`:`assertThat`の引数`(actual)`に実際の値を定義する。Serviceが返した実際の値をassertThat(検証/比較)している
 - `assertThat(actual).isEqualTo(期待値となる値)`:期待値は`.isEqualTo`の引数に定義する
 - アサーションのimport文に気を付ける
+
+### エラー
+
+- `staticでないメソッド deleteSkiresort(int)をstaticコンテキストから参照することはできません`:staticメソッドの呼び出し方だとエラー
+  -> staticメソッド = クラスメソッド
+  
 
 ### doReturnの書き方
 
@@ -158,25 +164,36 @@ Finished generating test html results (0.026 secs) into: /Users/yoko/git/raiseTe
     - `actual`:テストしたい実際の値をリスト型のactualに代入する
 
 - skiresortMapperに存在しないIDを指定した時エラーメッセージが返されること
-    - `throws Exception`:必要？不要？存在しないIDを指定した時にMapperは一体どんな値を返すのかを考える
-    - `assertThatThrownBy()`: 例外の検証ができる
-    - `isinstanceof()`:対象のメソッドを実行した時にthrowされる例外が、何インスタンスか？を検証している
-    - `ResourceNotFoundException`:指定したIDに該当するリソースがないことを通知する例外
+  - `throws Exception`:必要？不要？存在しないIDを指定した時にMapperは一体どんな値を返すのかを考える
+  - `assertThatThrownBy()`: 例外の検証ができる
+  - `isinstanceof()`:対象のメソッドを実行した時にthrowされる例外が、何インスタンスか？を検証している
+  - `ResourceNotFoundException`:指定したIDに該当するリソースがないことを通知する例外
 
 - 指定したIDの情報を更新できること
 
 1. `skiresortMapper`の`findById`メソッドを使って更新前のデータを取得する ->`doReturn -when`:whenに更新前データを定義する
 2. `skiresortServiceImpl`オブジェクトの`updateSkiresort`メソッドを呼び出す。このメソッドは、指定したIDのスキーリゾート情報を更新する->`Lake Louise`
 3. `verify`:skiresortMapperオブジェクトのID1が1回呼ばれたことの検証。
-4. 新しい`Skiresort`インスタンスを作成し、変数`updateSkiresort`に更新後データ`Lake Louise`を設定する。->
-   Skiresortのインスタンス化updateSkiresortを定義しないとエラー
-5.
-    - `verify`:skiresortMapperオブジェクトのupdateSkiresortメソッドが1回呼ばれたことの検証
-    - verifyの検証時に`updateSkiresort`を渡す-> `MockitoはskiresortMapper.updateSkiresort`に更新後の`Lake Louise`
-      の情報が渡されたのだよねという検証までしてくれる
+4. 新しい`Skiresort`インスタンスを作成し、変数`updateSkiresort`に更新後データ`Lake Louise`を設定する。-> Skiresortのインスタンス化updateSkiresortを定義しないとエラーになる
+5. `updateSkiresort`: 戻り値がvoidなのでassertThatできない -> 代替としてverifyでfindByIdを使って検証する
+   - `verify`:skiresortMapperオブジェクトのupdateSkiresortメソッドが1回呼ばれたことの検証
+   - verifyの検証時に`updateSkiresort`を渡す-> `MockitoはskiresortMapper.updateSkiresort`に更新後の`Lake Louise`
+     の情報が渡されたのだよねという検証までしてくれる
 
 - updateSkiresortに存在しないIdを指定したらエラーメッセージが返されること
-- `assertThatThrownBy`:例外の検証ができる
+  - `assertThatThrownBy`:例外の検証ができる。`ResourceNotFoundException`をthrowされることを期待している
+  - `isInstanceOf`:throwされた例外が`ResourceNotFoundException`のインスタンスであることを検証する
+  
+- 指定したIDのスキー場情報を削除する
+  - `doReturn`:対象のIDのスキー場情報をモック化して`when`でskiresortMapperで対象IDを検索する
+  - `void`：deleteSkiresortはvoidのため、assertThatは使えない -> findByIdで呼び出す
+  - staticでないメソッド deleteSkiresort(int)をstaticコンテキストから参照することはできませんエラーが表示->staticメソッドの呼び出し方だとエラー->staticメソッド = クラスメソッド
+
+
+
+
+
+
 
 【折りたたみ】
 

--- a/src/test/java/com/example/raisetechcoursetask10/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/raisetechcoursetask10/service/SkiresortServiceImplTest.java
@@ -77,7 +77,7 @@ class SkiresortServiceImplTest {
         // updateSkiresortメソッドを呼び出して、id1が持つ情報をLake Louiseに更新する
         skiresortServiceImpl.updateSkiresort(1, "Lake Louise", "Canada", "バンフから近くて無料シャトルバスがある。広大で美しいゲレンデ");
 
-        // skiresortMapperオブジェクトのID1が1回呼ばれたことの検証（updteSkiresortは戻り値がvoidなのでassertThatでの検証ができない）
+        // skiresortMapperオブジェクトのID1が1回呼ばれたことの検証（updateSkiresortは戻り値がvoidなのでassertThatでの検証ができない）
         verify(skiresortMapper, times(1)).findById(1);
 
         // Skiresortのインスタンス定義

--- a/src/test/java/com/example/raisetechcoursetask10/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/raisetechcoursetask10/service/SkiresortServiceImplTest.java
@@ -77,7 +77,7 @@ class SkiresortServiceImplTest {
         // updateSkiresortメソッドを呼び出して、id1が持つ情報をLake Louiseに更新する
         skiresortServiceImpl.updateSkiresort(1, "Lake Louise", "Canada", "バンフから近くて無料シャトルバスがある。広大で美しいゲレンデ");
 
-        // skiresortMapperオブジェクトのID1が1回呼ばれたことの検証
+        // skiresortMapperオブジェクトのID1が1回呼ばれたことの検証（updteSkiresortは戻り値がvoidなのでassertThatでの検証ができない）
         verify(skiresortMapper, times(1)).findById(1);
 
         // Skiresortのインスタンス定義
@@ -91,12 +91,26 @@ class SkiresortServiceImplTest {
     @Test
     // updateSkiresortメソッドに対するテスト
     public void 指定したIDが存在しない時にエラーメッセージが返されること() {
-
+        // skiresortMapperのfindByIdメソッドが100を指定したときモック化されたメソッドが存在しないため空のOptionalを返す->IDが100のスキーリゾートが存在しない状態
         doReturn(Optional.empty()).when(skiresortMapper).findById(100);
 
+        // updateSkiresortメソッドを実行した時にthrowされる例外がResourceNotFoundExceptionクラスのインスタンスであることを期待している
         assertThatThrownBy(() -> skiresortServiceImpl.updateSkiresort(100, "Coronet Peak", "NZ", "海外遠征で初めて滑ったスキー場。すごく広くてクイーンズタウンからも近い")) // テスト対象メソッド)
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("resource not found");
         verify(skiresortMapper, times(1)).findById(100);
+    }
+
+    @Test
+    public void 指定したIDのスキー場情報を削除できること() {
+        doReturn(Optional.of(new Skiresort(1, "白馬乗鞍", "長野県", "初めてペンションに居候として山籠りし、初めて草大会に出場した思い出のゲレンデ"))).when(skiresortMapper).findById(1);
+
+        // staticメソッド（クラスメソッド）の呼び出し方はNG
+        // deleteSkiresortメソッドを呼び出す。引数は削除するIDのスキー場情報が渡される
+        skiresortServiceImpl.deleteSkiresort(1);
+
+        // deleteSkiresortはvoidなのでassertThat使用不可->findByIdで検証する
+        verify(skiresortMapper,times(1)).findById(1);
+        verify(skiresortMapper, times(1)).deleteSkiresort(1);
     }
 }

--- a/src/test/java/com/example/raisetechcoursetask10/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/raisetechcoursetask10/service/SkiresortServiceImplTest.java
@@ -109,7 +109,7 @@ class SkiresortServiceImplTest {
         // deleteSkiresortメソッドを呼び出す。引数は削除するIDのスキー場情報が渡される
         skiresortServiceImpl.deleteSkiresort(1);
 
-        // deleteSkiresortはvoidなのでassertThat使用不可->findByIdで検証する
+        // deleteSkiresortはvoidなのでassertThat使用不可->verifyで検証する
         verify(skiresortMapper,times(1)).findById(1);
         verify(skiresortMapper, times(1)).deleteSkiresort(1);
     }


### PR DESCRIPTION
# Service単体テスト：存在するIDを指定して、スキー場情報が削除できるかのをテストする

## 実装ポイント
- `deleteSkiresort`はvoidのため戻り値を持たない。->assertThatは使えないので、verifyで検証する必要がある
- `SkiresortServiceImpl.deleteSkiresort(1);`:staticメソッド（クラスメソッド）の呼び出し方をするとエラーになる


## 動作確認キャプチャ

![6DD2FA1E-1CD2-4CC7-9617-7E2BB448C1F6_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/9faa47c6-3d3d-453b-a5b0-dc0fe9e84cf5)

## テスト結果レポート

![4EA0F2C1-B674-4389-94BC-69714401F15F](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/f1d7984a-2470-4bd9-929e-ce67a3c0f02d)

![F5014A17-D0FD-44D0-9093-E21D20550672](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/a508f568-b969-4af3-b34a-abe8c3195184)
