### PR TITLE
結合テスト：IDを指定してスキーリゾート情報を更新した時のテスト実装

### DIFF
--- a/memo/it-memo.md
+++ b/memo/it-memo.md
@@ -13,13 +13,14 @@
 
 `MockMvc`:リクエストの検証
 `AutoConfigureMockMvc`:自動でMockMvcを行う
+`.content()`:リクエストボディを設定する
 
 テキストブロック:`"""`ダブルウォーと3つでラップした文字列をひとつの塊として扱う(Java13以降)
 
 ### すべてのスキーリゾートを全件取得したときステータスコードが200を返すこと
 
 - `@DataSet(value = "datasets/it-skiresort.yml")`:テスト初期データ。データセットなのでSkiresortで定義しているデータを設定すること
-- `JSONAssert`:初期データとの比較。期待値を定義するが、HTTPレスポンスなのでSkiresortResponseで定義しているデータのみを設定すること
+- `JSONAssert`:初期データとのJSONデータの比較。期待値を定義するが、HTTPレスポンスなのでSkiresortResponseで定義しているデータのみを設定すること
 
 ### 存在しないIDのスキーリゾートを取得した時ステータスコードが404エラーを返すこと
 
@@ -39,3 +40,47 @@
 リクエストボディを書く
 
 - `JSONAssert.assertEquals`: JSON形式で新規登録する情報を全て記述する(SkiresortResponseのフィールドに合わせること)
+
+### IDを指定してスキーリゾート情報を更新する
+
+- `isOK()`: リクエスト成功
+- SkiresortUpdateFormのフィールドの値を設定する
+
+リクエストボディ
+
+- `JSONAssert.assertEquals`: SkiresortControllerのReturnに定義されているレスポンス内容をJSON形式で書く
+
+### 存在しないIDを指定してスキーリゾートを更新すると期待通りのエラーが返ってくる
+
+- ISO 8601形式:日付と時刻を「T」で区切る
+- 時差:日本はUTC(協定世界時)から+9
+- 表記法:yyyy-MM-ddThh:mm:ss:SSSSSSSSSXXX
+- yyyy:年（4文字）
+- MM:月（2文字）
+- dd:日（2文字）
+- T:T文字（日付と時刻を区別するための文字）
+- HH:時（2文字）
+- mm:分（2文字）
+- ss:秒（2文字）
+- SSSSSSSSS:ナノ秒（9文字）
+- XXX:タイムゾーンオフセット
+
+リアルタイムでテスト不可の理由
+->timestampの比較:テスト実行のタイミングや実行速度がリアルタイムでは困難なため、厳密な一致を求めることが難しい
+
+- LocalDateTime nowDate = LocalDateTime.now(); 特定のタイムゾーンに依存しない場合の現在自刻の取得
+- ZoneDataTime now = ZonedDateTime now(); プログラムを実行した場所（国）での現在自刻の取得
+
+- `"/skiresorts/{id}", 100`:存在しないIDのパスを指定
+- assert.Equalsの内容
+    - "path":期待する値のパス->/skiresorts/100
+    - "status":期待するステータスコード
+    - "message":ステータスコードの対応したエラーメッセージ
+    - "timestamp":今回は適当。ISO 8601形式にしたがって記載
+    - "error":ステータスコードに対応したエラー
+- `JSONCompareMode.STRICT`:JSON比較モードで、全てのフィールドが一致していること
+- `((o1, o2) -> true)`:object1,2は常にtrueを返す->timestampの値は比較除外される
+
+### よく出るエラー
+
+- Could not create dataset for test:テスト実行中datasetを作成できなかったor正しく読み込めなかった->パスが合ってるか？

--- a/src/main/java/com/example/raisetechcoursetask10/controller/form/SkiresortUpdateForm.java
+++ b/src/main/java/com/example/raisetechcoursetask10/controller/form/SkiresortUpdateForm.java
@@ -1,14 +1,15 @@
 package com.example.raisetechcoursetask10.controller.form;
 
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public class SkiresortUpdateForm {
-    @NotNull
+    @NotBlank
     private final String name;
-    @NotNull
+    @NotBlank
+
     private String area;
-    @NotNull
+    @NotBlank
     private String customerEvaluation;
 
     public SkiresortUpdateForm(String name, String area, String customerEvaluation) {

--- a/src/test/java/com/example/raisetechcoursetask10/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/raisetechcoursetask10/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -5,8 +5,10 @@ import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -112,6 +114,63 @@ public class SkiresortRestApiIntegrationTest {
                         "area": "Canada"
                     }                  
                     """, response, JSONCompareMode.STRICT);
+        }
+
+        @Nested
+        class UpdateTest {
+            @Test
+            @DataSet(value = "datasets/it/skiresort.yml")
+            @ExpectedDataSet(value = "datasets/it/update-skiresort.yml")
+            @Transactional
+            void 存在するIDを指定してスキーリゾート情報を更新するとステータスコード200を返すこと() throws Exception {
+                String response = mockMvc.perform(MockMvcRequestBuilders.patch("/skiresorts/{id}", 3)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                              "id": 3,
+                                              "name": "Treble Cone",
+                                              "area": "NewZealand",
+                                              "customerEvaluation": "Features a long course with views of Lake Wanaka"
+                                        }                                      
+                                        """))
+                        .andExpect(MockMvcResultMatchers.status().isOk())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+                JSONAssert.assertEquals("""
+                        {
+                            "message": "successfully update"
+                        }                   
+                        """, response, JSONCompareMode.STRICT);
+            }
+
+            @Test
+            @DataSet(value = "datasets/it/skiresort.yml")
+            @Transactional
+            void 存在しないIDのスキーリゾートを更新した時ステータスコード404を返すこと() throws Exception {
+                String response = mockMvc.perform(MockMvcRequestBuilders.patch("/skiresorts/{id}", 100)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "id": 100,
+                                            "name": "Blue Mountain",
+                                            "area": "Canada",
+                                            "customerEvaluation": "All of the lodges and ski houses are cute, like a dreamland"
+                                        }                                                              
+                                        """))
+                        .andExpect(MockMvcResultMatchers.status().isNotFound())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+                JSONAssert.assertEquals("""
+                        {
+                            "path": "/skiresorts/100",
+                            "status": "404",
+                            "message": "resource not found",
+                            "timestamp": "2023-10-20T20:48.123456789+09:00[JST/Tokyo]",
+                            "error": "Not Found"
+                        }
+                        // timestampは比較対象外
+                        """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", ((o1, o2) -> true))));
+            }
         }
     }
 }

--- a/src/test/resources/datasets/it/fail-update-skiresort.yml
+++ b/src/test/resources/datasets/it/fail-update-skiresort.yml
@@ -1,0 +1,16 @@
+skiresort:
+
+  - id: 1
+    name: "LakeLouise"
+    area: "Canada"
+    customerEvaluation: "Canada's most beautiful skiresort area"
+
+  - id: 2
+    name: "Vail"
+    area: "Colorado"
+    customerEvaluation: "It's the most popular place in America, but I've never been there yet"
+
+  - id: 3
+    name: "Zermatt"
+    area: "Swiss"
+    customerEvaluation: "The most beautiful and popular in the world"

--- a/src/test/resources/datasets/it/update-skiresort.yml
+++ b/src/test/resources/datasets/it/update-skiresort.yml
@@ -1,0 +1,16 @@
+skiresort:
+
+  - id: 1
+    name: "LakeLouise"
+    area: "Canada"
+    customerEvaluation: "Canada's most beautiful skiresort area"
+
+  - id: 2
+    name: "Vail"
+    area: "Colorado"
+    customerEvaluation: "It's the most popular place in America, but I've never been there yet"
+
+  - id: 3
+    name: "Treble Cone"
+    area: "NewZealand"
+    customerEvaluation: "Features a long course with views of Lake Wanaka"


### PR DESCRIPTION
# IDを指定してスキーリゾート情報を更新した時のインテグレーションテスト

## 実装できたこと
- 存在するIDを指定して更新した時のテスト
- 存在しないIDを指定して更新した時のテスト

## 挑戦してできなかったこと
- リアルタイムで存在しないIDを指定して更新した時のテスト
- 全ての項目の値をnull又は空文字で更新した時のテスト

## 確認事項
- CIにて正常にテストコードZipファイル作成の成功

## 動作確認キャプチャ
![7A860D1D-EEFC-4601-9775-EBE4E4672D12_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/f95ae1a8-2b05-4bbf-8b52-f81f4ba37b69)
