### PR TITLE
CustomExceptionHandlerの実装を整理/カラムの桁数の変更

### DIFF
--- a/memo/validation-memo.md
+++ b/memo/validation-memo.md
@@ -18,3 +18,16 @@
 - 空文字:文字列が0のこと。
 - null:箱も中身もない。何も存在しない。
 - blanc:箱はあるけど何も入ってない。半角スペース、全角スペースのこと。
+
+@Validated:@Validを拡張したSpringの機能
+@Validated:@RequestParamアノテーションを使用する場合
+@Valid:Jakarta Bean Validationで定義される
+
+### 仮説を立ててデバッグ実行
+
+@ExceptionHandlerで通るか？（問題がなければ通らない->問題が0個なら通らない）
+`MethodArgumentNotValidExceptjon`:Controllerに`@Valid`や`@Validated`をつけたuserPostrequestをentityでバリデーションした（@NotBlankなど）結果
+->Not Valid（正しくない）例外になるハンドラーである
+->postリクエストを送ると返ってくる（返ってくる＝失敗）
+->正しい場合:例外は出ない
+->ExceptionHandlerを通る場合またはControllerを通る場合に分かれる

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -2,9 +2,9 @@ DROP TABLE IF EXISTS skiresort;
 
 CREATE TABLE skiresort (
   id int unsigned AUTO_INCREMENT,
-  name VARCHAR(100) NOT NULL,
-  area VARCHAR(100) NOT NULL,
-  customerEvaluation VARCHAR(255) NOT NULL,
+  name VARCHAR(20) NOT NULL,
+  area VARCHAR(20) NOT NULL,
+  customerEvaluation VARCHAR(100) NOT NULL,
   PRIMARY KEY(id)
 );
 

--- a/src/main/java/com/example/raisetechcoursetask10/controller/SkiresortController.java
+++ b/src/main/java/com/example/raisetechcoursetask10/controller/SkiresortController.java
@@ -4,14 +4,10 @@ import com.example.raisetechcoursetask10.controller.form.SkiresortCreateForm;
 import com.example.raisetechcoursetask10.controller.form.SkiresortUpdateForm;
 import com.example.raisetechcoursetask10.controller.response.SkiresortResponse;
 import com.example.raisetechcoursetask10.entity.Skiresort;
-import com.example.raisetechcoursetask10.exception.ResourceNotFoundException;
 import com.example.raisetechcoursetask10.service.SkiresortService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -44,21 +39,6 @@ public class SkiresortController {
     public SkiresortResponse getSkiresortById(@PathVariable("id") int id) {
         Skiresort skiresort = skiresortService.findById(id);
         return new SkiresortResponse(skiresort);
-    }
-
-    @ExceptionHandler(value = ResourceNotFoundException.class)
-    public ResponseEntity<Map<String, String>> noResourceFound(
-            ResourceNotFoundException e, HttpServletRequest request) {
-
-        Map<String, String> body = Map.of(
-                "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-                "message", e.getMessage(),
-                "path", request.getRequestURI());
-
-        // 404エラーを返す
-        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
     }
 
     @PostMapping("/skiresorts")

--- a/src/main/java/com/example/raisetechcoursetask10/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/raisetechcoursetask10/exception/CustomExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.raisetechcoursetask10.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -8,6 +9,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -38,4 +40,20 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
         // 400エラーを返す
         return ResponseEntity.badRequest().body(body);
     }
+
+    @ExceptionHandler(value = ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> noResourceFound(
+            ResourceNotFoundException e, HttpServletRequest request) {
+
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+
+        // 404エラーを返す
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+
 }


### PR DESCRIPTION
# CustomExceptionHandlerの実装を整理/カラムの桁数の変更

## やったこと
- Controller：@ExceptionHandlerをCustomExceptionHandlerへ移動
- sql：name,area,customerEvaluationのサイズを変更

## 確認ポイント
- アプリケーションの正常終了
- GitHub Actionsでテストレポートの生成