### PR TITLE
areaに関するバリデーションを実装

### DIFF
--- a/memo/validation-memo.md
+++ b/memo/validation-memo.md
@@ -49,7 +49,8 @@
 - `@Size`デフォルトメッセージ:"{min} から {max} の間のサイズにしてください"
 - `.extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)`
     - `extracting `:AssertJライブラリの一部で、リストやコレクションから特定の要素を抽出して検証する
-    - `violations`:リストの各要素に対して、ConstraintViolationオブジェクト(nameやarea)を文字列に変換し、ConstraintViolationオブジェクト(
+    - `violations`(検証エラーのリスト):リストの各要素に対して、ConstraintViolationオブジェクト(nameやarea)
+      を文字列に変換し、ConstraintViolationオブジェクト(
       バリデーションエラーが発生した際に生成されるオブジェクト)からエラーメッセージを取得する
     - `containsExactlyInAnyOrder`:期待されるプロパティパス(バリデーションエラーが発生した場所)、エラーメッセージと実際の結果が一致することを検証する
 - Formフィールドのアノテーション:messageは全てのアノテーションに書くか書かないかを統一すること

--- a/src/test/java/com/example/raisetechcoursetask10/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/raisetechcoursetask10/controller/form/SkiresortCreateFormTest.java
@@ -25,7 +25,7 @@ class SkiresortCreateFormTest {
     }
 
     @Nested
-    class NameTest {
+    class NameSizeTest {
         @Test
         public void nameが1文字未満である時バリデーションエラーとなること() {
 
@@ -70,7 +70,7 @@ class SkiresortCreateFormTest {
     }
 
     @Nested
-    class AreaTest {
+    class AreaSizeTest {
 
         @Test
         public void areaが1文字未満である時バリデーションエラーとなること() {
@@ -112,6 +112,36 @@ class SkiresortCreateFormTest {
                     .containsExactlyInAnyOrder(
                             tuple("area", "1 から 20 の間のサイズにしてください")
                     );
+        }
+    }
+
+    @Nested
+    class AreaNotBlankTest {
+        @Test
+        public void areaが半角ブランクである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", " ", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("area", "空白は許可されていません"));
+        }
+
+        @Test
+        public void areaがNuLLである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", null, "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("area", "空白は許可されていません"));
+        }
+
+        @Test
+        public void areaが全角ブランクである時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "　", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
         }
     }
 }

--- a/src/test/java/com/example/raisetechcoursetask10/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/raisetechcoursetask10/controller/form/SkiresortCreateFormTest.java
@@ -70,6 +70,38 @@ class SkiresortCreateFormTest {
     }
 
     @Nested
+    class NameNotBlankTest {
+
+        @Test
+        public void nameが半角ブランクである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm(" ", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+        }
+
+        @Test
+        public void nameがnullである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm(null, "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+        }
+
+        @Test
+        public void nameが全角ブランクである時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("　", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+
+        }
+    }
+
+    @Nested
     class AreaSizeTest {
 
         @Test
@@ -117,6 +149,7 @@ class SkiresortCreateFormTest {
 
     @Nested
     class AreaNotBlankTest {
+
         @Test
         public void areaが半角ブランクである時バリデーションエラーとなること() {
             SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", " ", "Australia's widest ski slope");
@@ -128,7 +161,7 @@ class SkiresortCreateFormTest {
         }
 
         @Test
-        public void areaがNuLLである時バリデーションエラーとなること() {
+        public void areaがnuLLである時バリデーションエラーとなること() {
             SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", null, "Australia's widest ski slope");
             var violations = validator.validate(createForm);
             assertThat(violations).hasSize(1);

--- a/src/test/java/com/example/raisetechcoursetask10/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/raisetechcoursetask10/controller/form/SkiresortCreateFormTest.java
@@ -1,6 +1,5 @@
-package com.example.raisetechcoursetask10.validation;
+package com.example.raisetechcoursetask10.controller.form;
 
-import com.example.raisetechcoursetask10.controller.form.SkiresortCreateForm;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -14,8 +13,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
-public class SkiresortCreateFormTest {
-
+class SkiresortCreateFormTest {
     private static Validator validator;
 
     // 一番最初に一度だけ実行される

--- a/src/test/java/com/example/raisetechcoursetask10/validation/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/raisetechcoursetask10/validation/SkiresortCreateFormTest.java
@@ -65,7 +65,55 @@ public class SkiresortCreateFormTest {
             assertThat(violations).hasSize(1);
             assertThat(violations)
                     .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                    .containsExactlyInAnyOrder(tuple("name", "1 から 20 の間のサイズにしてください"));
+                    .containsExactlyInAnyOrder(
+                            tuple("name", "1 から 20 の間のサイズにしてください")
+                    );
+        }
+    }
+
+    @Nested
+    class AreaTest {
+
+        @Test
+        public void areaが1文字未満である時バリデーションエラーとなること() {
+
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(2);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    // 特定の条件が順不要で一致することの検証
+                    .containsExactlyInAnyOrder(
+                            tuple("area", "空白は許可されていません"),
+                            tuple("area", "1 から 20 の間のサイズにしてください")
+                    );
+        }
+
+        @Test
+        public void areaが1文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "a", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            // エラーなしであることの検証
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaが20文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "12345678901234567890", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaが21文字である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "123456789012345678901", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("area", "1 から 20 の間のサイズにしてください")
+                    );
         }
     }
 }


### PR DESCRIPTION
# class AreaTest:areaの境界値に対するバリデーションを実装

## バリデーション内容
- `@Size`(min = 1, max = 20):1文字以上20文字以下であること
- `@NotBlank`:null/空文字/スペースは許可していないこと

## 確認ポイント
- GitHub Actionsでテストレポートが自動生成されていること

## 動作確認キャプチャ

![5345F74A-19D0-4FEC-8272-0B89F567C5E5_1_201_a](https://github.com/yoko-newDeveloper/raiseTech-course-task10/assets/91002836/e467f0d0-516e-4ed8-8ccc-38376c273af8)
